### PR TITLE
Serve login page from frontend

### DIFF
--- a/common/components/Login.js
+++ b/common/components/Login.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Login = props => (
+  <div>Login</div>
+);

--- a/common/components/Login.js
+++ b/common/components/Login.js
@@ -3,3 +3,5 @@ import React from 'react';
 const Login = props => (
   <div>Login</div>
 );
+
+export default Login;

--- a/common/components/Login.js
+++ b/common/components/Login.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { StyleSheet, css } from 'aphrodite';
+import config from '../../server/config';
 
 const styles = StyleSheet.create({
   root: {
@@ -30,13 +31,13 @@ const Login = props => (
     <div className={css(styles.loginForm)}>
       <h1 className={css(styles.header)}>Notist</h1>
       <br />
-      <a
+      <a href={`http://${config.apiHost}/login/facebook`}
         className={`btn btn-block btn-social btn-lg btn-facebook ${css(styles.button)}`}
       >
         <i className="fa fa-facebook" /> Sign in with Facebook
       </a>
       <br />
-      <a
+      <a href={`http://${config.apiHost}/auth/google`}
         className={`btn btn-block btn-social btn-lg btn-google ${css(styles.button)}`}
       >
         <i className="fa fa-google" /> Sign in with Google

--- a/common/components/Login.js
+++ b/common/components/Login.js
@@ -1,7 +1,48 @@
 import React from 'react';
+import { StyleSheet, css } from 'aphrodite';
+
+const styles = StyleSheet.create({
+  root: {
+    position: 'absolute',
+    top: '20%',
+    width: '100%',
+  },
+  loginForm: {
+    position: 'relative',
+    width: '50%',
+    textAlign: 'center',
+    margin: '0 auto',
+  },
+  header: {
+    fontSize: 80,
+    lineHeight: 1,
+  },
+  button: {
+    width: '25%',
+    display: 'block',
+    margin: '0 auto',
+    top: '20px',
+  },
+});
 
 const Login = props => (
-  <div>Login</div>
+  <div className={css(styles.root)}>
+    <div className={css(styles.loginForm)}>
+      <h1 className={css(styles.header)}>Notist</h1>
+      <br />
+      <a
+        className={`btn btn-block btn-social btn-lg btn-facebook ${css(styles.button)}`}
+      >
+        <i className="fa fa-facebook" /> Sign in with Facebook
+      </a>
+      <br />
+      <a
+        className={`btn btn-block btn-social btn-lg btn-google ${css(styles.button)}`}
+      >
+        <i className="fa fa-google" /> Sign in with Google
+      </a>
+    </div>
+  </div>
 );
 
 export default Login;

--- a/common/routes/Login.js
+++ b/common/routes/Login.js
@@ -1,0 +1,6 @@
+import Login from '../components/Login';
+
+export default {
+  path: '/login',
+  component: Login,
+};

--- a/common/routes/root.js
+++ b/common/routes/root.js
@@ -1,12 +1,11 @@
 import App from '../components/App';
-import Login from '../components/Login';
 import Home from './Home';
 
 // polyfill webpack require.ensure
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require);
 
 export default function createRoutes(store) {
-  const root = {
+  return {
     path: '/',
     component: App,
     getChildRoutes(location, cb) {
@@ -14,20 +13,14 @@ export default function createRoutes(store) {
         cb(null, [
           require('./PostList').default(store), // no need to modify store, no reducer
           require('./Post').default(store), // add async reducer
+          require('./Login').default,
           require('./NotFound').default,
         ]);
       });
     },
 
-    loginRoute: {
-      path: '/login',
-      component: Login,
-    }
-
     indexRoute: {
       component: Home,
     },
   };
-
-  return root;
 }

--- a/common/routes/root.js
+++ b/common/routes/root.js
@@ -1,26 +1,29 @@
 import App from '../components/App';
 import Home from './Home';
+import loginRoute from './Login';
 
 // polyfill webpack require.ensure
 if (typeof require.ensure !== 'function') require.ensure = (d, c) => c(require);
 
 export default function createRoutes(store) {
-  return {
-    path: '/',
-    component: App,
-    getChildRoutes(location, cb) {
-      require.ensure([], (require) => {
-        cb(null, [
-          require('./PostList').default(store), // no need to modify store, no reducer
-          require('./Post').default(store), // add async reducer
-          require('./Login').default,
-          require('./NotFound').default,
-        ]);
-      });
-    },
+  return [
+    loginRoute,
+    {
+      path: '/',
+      component: App,
+      getChildRoutes(location, cb) {
+        require.ensure([], (require) => {
+          cb(null, [
+            require('./PostList').default(store), // no need to modify store, no reducer
+            require('./Post').default(store), // add async reducer
+            require('./NotFound').default,
+          ]);
+        });
+      },
 
-    indexRoute: {
-      component: Home,
+      indexRoute: {
+        component: Home,
+      },
     },
-  };
+  ];
 }

--- a/common/routes/root.js
+++ b/common/routes/root.js
@@ -1,4 +1,5 @@
 import App from '../components/App';
+import Login from '../components/Login';
 import Home from './Home';
 
 // polyfill webpack require.ensure
@@ -17,6 +18,11 @@ export default function createRoutes(store) {
         ]);
       });
     },
+
+    loginRoute: {
+      path: '/login',
+      component: Login,
+    }
 
     indexRoute: {
       component: Home,

--- a/server/config.js
+++ b/server/config.js
@@ -3,7 +3,7 @@ const config = {
   webConcurrency: process.env.WEB_CONCURRENCY || 1,
   port: process.env.PORT || 5000,
   timeout: 29000,
-  apiHost: process.env.NODE_ENV === 'production' ?  'notist.herokuapp.com' : 'localhost:3000',
-}
+  apiHost: process.env.NODE_ENV === 'production' ? 'notist.herokuapp.com' : 'localhost:3000',
+};
 
-module.exports = config
+module.exports = config;

--- a/server/config.js
+++ b/server/config.js
@@ -2,7 +2,8 @@ const config = {
   nodeEnv: process.env.NODE_ENV,
   webConcurrency: process.env.WEB_CONCURRENCY || 1,
   port: process.env.PORT || 5000,
-  timeout: 29000
+  timeout: 29000,
+  apiHost: process.env.NODE_ENV === 'production' ?  'notist.herokuapp.com' : 'localhost:3000',
 }
 
 module.exports = config

--- a/server/index.js
+++ b/server/index.js
@@ -124,6 +124,9 @@ export const createServer = (config) => {
                 ${head.title.toString()}
                 <meta name="viewport" content="width=device-width, initial-scale=1">
                 <link rel="shortcut icon" href="/favicon.ico">
+                <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+                <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+                <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-social/5.1.1/bootstrap-social.min.css">
                 ${head.meta.toString()}
                 ${head.link.toString()}
                 <style>


### PR DESCRIPTION
Previously we have had our login page served from the backend api, which was bad because it should just serve json responses and not html pages. This makes it so that we serve the login page from the frontend, at the '/login' route. Successful login will redirect the user to the feed view once some corresponding changes on the backend are merged.
![notistlogin](https://cloud.githubusercontent.com/assets/6070087/24841128/50acffee-1d4a-11e7-804c-c788c4ae08bb.gif)

