### PR TITLE
Join group button

### DIFF
--- a/common/actions/groups.js
+++ b/common/actions/groups.js
@@ -18,18 +18,25 @@ export function saveGroup(group) {
     });
 }
 
-export function updateUser(groups, username) {
+export function updateUser(groups, username, _id, bio, usersFollowingMe, usersIFollow, exploreNumber, numExplorations, exploreStandardDev) {
   return {
     type: types.UPDATE_USER,
     groups,
-    username,
+    name,
+    _id,
+    bio,
+    usersFollowingMe,
+    usersIFollow,
+    exploreNumber,
+    numExplorations,
+    exploreStandardDev,
   };
 }
 
 export function fetchUser() {
   return (dispatch, getState) => {
     api.fetchUser().then((user) => {
-      dispatch(updateUser(user.groups, user.username));
+      dispatch(updateUser(user.groups, user.username, user._id, user.bio, user.usersFollowingMe, user.usersIFollow, user.exploreNumber, user.numExplorations, user.exploreStandardDev));
     });
   };
 }

--- a/common/api.js
+++ b/common/api.js
@@ -119,7 +119,6 @@ export const saveReply = (text, parent, articleURI) => {
 };
 
 export const toggleGroupMembership = (groupId, userId) => { // ?userId=USERB.id
-  console.log(`GroupId is: ${groupId}`);
   return fetch(`${config.apiHost}/api/group/${groupId}/user?userId=${userId}`, {
     method: 'POST',
     credentials: 'include',

--- a/common/api.js
+++ b/common/api.js
@@ -118,19 +118,11 @@ export const saveReply = (text, parent, articleURI) => {
   .then(res => handleResponse(res));
 };
 
-export const joinGroup = (groupId) => {
+export const toggleGroupMembership = (groupId, userId) => { // ?userId=USERB.id
   console.log(`GroupId is: ${groupId}`);
-  return fetch(`${config.apiHost}/api/group/${groupId}/user`, {
+  return fetch(`${config.apiHost}/api/group/${groupId}/user?userId=${userId}`, {
     method: 'POST',
     credentials: 'include',
     headers,
   }).then(res => handleResponse(res));        // '/api/group/:groupId/user'
-};
-
-export const leaveGroup = (groupId) => {
-  return fetch(`${config.apiHost}/api/group/${groupId}/user`, {
-    method: 'POST',
-    credentials: 'include',
-    headers,
-  }).then(res => handleResponse(res));
 };

--- a/common/api.js
+++ b/common/api.js
@@ -70,6 +70,14 @@ export const saveGroup = (group) => {
   .then(res => handleResponse(res));
 };
 
+export const fetchPublicGroups = () => {
+  return fetch(`${config.apiHost}/api/publicgroups`, {
+    method: 'GET',
+    credentials: 'include',
+    headers,
+  }).then(res => handleResponse(res));
+};
+
 export const saveReply = (text, parent, articleURI) => {
   return fetch(`${config.apiHost}/api/annotation`, {
     method: 'POST',

--- a/common/api.js
+++ b/common/api.js
@@ -18,6 +18,8 @@ const handleResponse = (res) => {
   if (res.status === 401) {
     return handleUnauthorizedRequest();
   } else {
+    console.log('Result!');
+    console.log(res);
     return res.json();
   }
 };

--- a/common/api.js
+++ b/common/api.js
@@ -117,3 +117,20 @@ export const saveReply = (text, parent, articleURI) => {
   })
   .then(res => handleResponse(res));
 };
+
+export const joinGroup = (groupId) => {
+  console.log(`GroupId is: ${groupId}`);
+  return fetch(`${config.apiHost}/api/group/${groupId}/user`, {
+    method: 'POST',
+    credentials: 'include',
+    headers,
+  }).then(res => handleResponse(res));        // '/api/group/:groupId/user'
+};
+
+export const leaveGroup = (groupId) => {
+  return fetch(`${config.apiHost}/api/group/${groupId}/user`, {
+    method: 'POST',
+    credentials: 'include',
+    headers,
+  }).then(res => handleResponse(res));
+};

--- a/common/api.js
+++ b/common/api.js
@@ -71,7 +71,7 @@ export const saveGroup = (group) => {
 };
 
 export const fetchPublicGroups = () => {
-  return fetch(`${config.apiHost}/api/publicgroups`, {
+  return fetch(`${config.apiHost}/api/public/groups`, {
     method: 'GET',
     credentials: 'include',
     headers,

--- a/common/api.js
+++ b/common/api.js
@@ -18,8 +18,6 @@ const handleResponse = (res) => {
   if (res.status === 401) {
     return handleUnauthorizedRequest();
   } else {
-    console.log('Result!');
-    console.log(res);
     return res.json();
   }
 };

--- a/common/api.js
+++ b/common/api.js
@@ -70,9 +70,34 @@ export const saveGroup = (group) => {
   .then(res => handleResponse(res));
 };
 
+export const getGroupMembers = (groupId) => {
+  return fetch(`${config.apiHost}/api/group/${groupId}/members`, {
+    method: 'GET',
+    credentials: 'include',
+    headers,
+  })
+  .then(res => handleResponse(res));
+};
+
 export const fetchPublicGroups = () => {
   return fetch(`${config.apiHost}/api/public/groups`, {
     method: 'GET',
+    credentials: 'include',
+    headers,
+  }).then(res => handleResponse(res));
+};
+
+export const editAnnotation = (annotationId) => { // Where do I add the body text to this? Is it a header or... ?
+  return fetch(`${config.apiHost}/api/annotation/${annotationId}/edit`, {
+    method: 'POST',
+    credentials: 'include',
+    headers,
+  }).then(res => handleResponse(res));
+};
+
+export const deleteAnnotation = (annotationId) => {
+  return fetch(`${config.apiHost}/api/annotation/${annotationId}`, {
+    method: 'DELETE',
     credentials: 'include',
     headers,
   }).then(res => handleResponse(res));

--- a/common/components/ArticleCard.js
+++ b/common/components/ArticleCard.js
@@ -35,6 +35,7 @@ const styles = StyleSheet.create({
     flex: 1,
     display: 'flex',
     flexDirection: 'column',
+    maxHeight: '300px',
   },
   imageStyle: {
     alignSelf: 'center',
@@ -143,9 +144,7 @@ class ArticleCard extends React.Component {
                 {/* <span><MdGroup /> {numUsers} users</span> */}
                 <span><MdComment /> {this.props.numAnnotations} {this.props.numAnnotations > 1 ? 'annotations' : 'annotation'}</span>
               </div>
-              <div className={css(styles.imageStyle)}>
-                <img height={'250px'} src={image || 'https://i.imgur.com/4h5V7Jp.jpg'} alt="article top" />
-              </div>
+              <img style={{ maxWidth: '80%', alignSelf: 'center' }} src={image || 'https://i.imgur.com/4h5V7Jp.jpg'} alt="article top" />
             </div> }
           </div>
           <CardActions className={css(styles.cardButtons)}>

--- a/common/components/ArticleCard.js
+++ b/common/components/ArticleCard.js
@@ -173,9 +173,9 @@ ArticleCard.propTypes = {
   domain: React.PropTypes.string.isRequired,
   subtitle: React.PropTypes.string.isRequired,
   annotationContent: React.PropTypes.string.isRequired,
-  numUsers: React.PropTypes.number.isRequired,
+  numUsers: React.PropTypes.number,
   numAnnotations: React.PropTypes.number.isRequired,
-  numReplies: React.PropTypes.number.isRequired,
+  numReplies: React.PropTypes.number,
   username: React.PropTypes.string.isRequired,
   timeSince: React.PropTypes.string.isRequired,
   image: React.PropTypes.string.isRequired,
@@ -183,4 +183,8 @@ ArticleCard.propTypes = {
   slug: React.PropTypes.string.isRequired,
 };
 
+ArticleCard.defaultProps = {
+  numUsers: 0,
+  numReplies: 0,
+};
 export default ArticleCard;

--- a/common/components/CreateGroupDialog.js
+++ b/common/components/CreateGroupDialog.js
@@ -105,7 +105,7 @@ class CreateGroupDialog extends React.Component {
   }
 }
 
-CreateGroupDialog.propTypes = {
+CreateGroupDialog.PropTypes = {
   validName: PropTypes.bool.isRequired,
   onChange: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,

--- a/common/components/GroupCard.js
+++ b/common/components/GroupCard.js
@@ -10,7 +10,7 @@ import { StyleSheet, css } from 'aphrodite';
 import PeopleIcon from 'material-ui/svg-icons/social/people';
 import { Link } from 'react-router';
 import moment from 'moment';
-import { leaveGroup, joinGroup } from '../routes/PostList/actions';
+import { toggleGroupMembership, fetchUser } from '../routes/PostList/actions';
 
 const styles = StyleSheet.create({
   flexContainer: {
@@ -91,20 +91,29 @@ class GroupCard extends React.Component {
   };
 
   handleSubscribeClick = () => {
-    if (this.state.subscribed) {
-      leaveGroup(this.props.groupId);
-    } else {
-      joinGroup(this.props.groupId);
-    }
+    toggleGroupMembership(this.props.groupId);
     this.setState({ subscribed: !this.state.subscribed });
+    console.log('Calling fetchUser!');
+    this.props.dispatch(fetchUser());
   }
 
   render() {
+    let name = 'Anonymous';
+    if (this.props.creatorName) {
+      name = this.props.creatorName;
+      const filteredName = this.props.creatorName.split(' ');
+
+      if (filteredName.length >= 2) {
+        if (filteredName[1].charAt(0)) { // If it's not null
+          name = `${`${filteredName[0]} ${filteredName[1][0]}`}.`;
+        }
+      }
+    }
+
     let subButton = null;
 
     console.log(this.props.createdDate);
     const timeSince = moment(this.props.createdDate).fromNow();
-    const name = this.props.creatorId;
 
     if (this.state.subscribed) { // Check if subscribed to group
       subButton = <RaisedButton className={css(styles.subButton)} label="unsubscribe" onClick={this.handleSubscribeClick} backgroundColor={red400} labelColor={grey100} />;
@@ -134,7 +143,7 @@ class GroupCard extends React.Component {
             </div>
           </div>
           <div className={css(styles.groupDescription)}>
-            This group is dedicated to something.
+            {this.props.description}
           </div>
         </Card>
       </MuiThemeProvider>
@@ -145,10 +154,12 @@ class GroupCard extends React.Component {
 GroupCard.propTypes = {
   groupId: React.PropTypes.string.isRequired,
   title: React.PropTypes.string.isRequired,
+  description: React.PropTypes.string.isRequired,
   createdDate: React.PropTypes.string.isRequired,
-  creatorId: React.PropTypes.string.isRequired,
+  creatorName: React.PropTypes.string.isRequired,
   numMembers: React.PropTypes.number.isRequired,
   subscribed: React.PropTypes.bool.isRequired,
+  dispatch: React.PropTypes.func.isRequired,
 };
 
 GroupCard.defaultProps = {

--- a/common/components/GroupCard.js
+++ b/common/components/GroupCard.js
@@ -87,15 +87,8 @@ class GroupCard extends React.Component {
     this.handleSubscribeClick = this.handleSubscribeClick.bind(this);
   }
 
-  state = {
-    subscribed: this.props.subscribed,
-  };
-
   handleSubscribeClick = () => {
     this.props.dispatch(toggleGroupMembership(this.props.groupId));
-    if (!this.props.error) {
-      this.setState({ subscribed: !this.state.subscribed });
-    }
   }
 
   render() {
@@ -115,7 +108,7 @@ class GroupCard extends React.Component {
 
     const timeSince = moment(this.props.createdDate).fromNow();
 
-    if (this.state.subscribed) { // Check if subscribed to group
+    if (this.props.subscribed) { // Check if subscribed to group
       subButton = <RaisedButton className={css(styles.subButton)} label="unsubscribe" onClick={this.handleSubscribeClick} backgroundColor={red400} labelColor={grey100} />;
     } else {
       subButton = <RaisedButton className={css(styles.subButton)} label="subscribe" onClick={this.handleSubscribeClick} backgroundColor={yellow200} labelColor={grey900} />;
@@ -154,7 +147,6 @@ class GroupCard extends React.Component {
 GroupCard.propTypes = {
   groupId: React.PropTypes.string.isRequired,
   title: React.PropTypes.string.isRequired,
-  error: React.PropTypes.string,
   description: React.PropTypes.string.isRequired,
   createdDate: React.PropTypes.string.isRequired,
   creatorName: React.PropTypes.string.isRequired,
@@ -166,12 +158,8 @@ GroupCard.propTypes = {
 GroupCard.defaultProps = {
   groupId: '',
   title: 'Group Title',
-  subscribed: true,
+  subscribed: false,
   error: '',
 };
 
-const mapStateToProps = state => ({
-  error: state.articles.error,
-});
-
-export default connect(mapStateToProps)(GroupCard);
+export default connect()(GroupCard);

--- a/common/components/GroupCard.js
+++ b/common/components/GroupCard.js
@@ -1,0 +1,143 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable max-len */
+
+import React from 'react';
+import { Card, CardActions } from 'material-ui/Card';
+import { yellow200, yellow400, red700, grey900, fullBlack, deepOrange100, indigo100, amber100, teal100 } from 'material-ui/styles/colors';
+import RaisedButton from 'material-ui/RaisedButton';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import { StyleSheet, css } from 'aphrodite';
+import { Link } from 'react-router';
+
+const styles = StyleSheet.create({
+  flexContainer: {
+    display: 'flex',
+    paddingLeft: 30,
+    paddingTop: 10,
+    paddingRight: 30,
+    '@media (max-width: 1000px)': {
+      flexDirection: 'column',
+    },
+  },
+  articleTitleBar: {
+    paddingLeft: 30,
+    paddingTop: 10,
+    paddingRight: 10,
+  },
+  leftFlex: {
+    flex: 2,
+  },
+  rightFlex: {
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  imageStyle: {
+    alignSelf: 'center',
+  },
+  usersAndAnnotations: {
+    display: 'flex',
+    justifyContent: 'space-around',
+    '@media (max-width: 1000px)': {
+      display: 'none',
+    },
+  },
+  cardButtons: {
+    paddingTop: 40,
+    display: 'flex',
+    alignSelf: 'center',
+    justifyContent: 'center',
+    '@media (max-width: 900px)': {
+      flexDirection: 'column',
+      margin: 10,
+      alignItems: 'center',
+    },
+  },
+  bottomButton: {
+    '@media (max-width: 900px)': {
+      marginTop: 15,
+    },
+  },
+  annotationTextStyle: {
+    position: 'relative',
+    fontSize: 21,
+  },
+  articleTitleTextStyle: {
+    fontWeight: 700,
+    fontSize: 33,
+  },
+  articleTextStyle: {
+    fontSize: 24,
+    fontStyle: 'italic',
+    fontWeight: 100,
+    backgroundColor: yellow200,
+  },
+  domainTextStyle: {
+    fontSize: 17,
+    textDecoration: 'underline',
+  },
+  publishedTime: {
+    fontSize: 15,
+  },
+});
+
+class GroupCard extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.handleSubscribeClick = this.handleSubscribeClick.bind(this);
+  }
+
+  state = {
+    subscribed: this.props.subscribed,
+  };
+
+  handleSubscribeClick = () => {
+    this.setState({ subscribed: !this.state.subscribed });
+  }
+
+  render() {
+    let subButton = null;
+
+    if (this.state.subscribed) { // Check if subscribed to group
+      subButton = <RaisedButton label="subscribe" onClick={this.handleSubscribeClick} backgroundColor={yellow400} labelColor={grey900} />;
+    } else {
+      subButton = <RaisedButton label="unsubscribe" onClick={this.handleSubscribeClick} backgroundColor={red700} />;
+    }
+
+    let cardStyle;
+    if (this.props.narrowCard) {
+      cardStyle = {
+        maxWidth: '40%',
+        margin: 30,
+      };
+    } else {
+      cardStyle = {
+        margin: 30,
+      };
+    }
+
+    return (
+      <MuiThemeProvider>
+        <Card style={cardStyle}>
+          <div className={css(styles.articleTitleBar)}>
+            <p>{this.props.title}</p>
+          </div>
+          {subButton}
+        </Card>
+      </MuiThemeProvider>
+    );
+  }
+}
+
+GroupCard.propTypes = {
+  title: React.PropTypes.string.isRequired,
+  subscribed: React.PropTypes.bool.isrequired,
+};
+
+GroupCard.defaultProps = {
+  title: 'Group Title',
+  subscribed: true,
+};
+
+export default GroupCard;

--- a/common/components/GroupCard.js
+++ b/common/components/GroupCard.js
@@ -25,6 +25,11 @@ const styles = StyleSheet.create({
     paddingTop: 10,
     paddingRight: 10,
   },
+  subButton: {
+    margin: 'auto',
+    float: 'left',
+    lign: 'right',
+  },
   leftFlex: {
     flex: 2,
   },
@@ -129,7 +134,10 @@ class GroupCard extends React.Component {
           <div className={css(styles.articleTitleBar)}>
             <p>{this.props.title}</p>
           </div>
-          {subButton}
+          <div className={css(styles.subButton)}>
+            {subButton}
+          </div>
+          <div style={{ clear: 'both' }} />
         </Card>
       </MuiThemeProvider>
     );

--- a/common/components/GroupCard.js
+++ b/common/components/GroupCard.js
@@ -9,6 +9,7 @@ import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import { StyleSheet, css } from 'aphrodite';
 import PeopleIcon from 'material-ui/svg-icons/social/people';
 import { Link } from 'react-router';
+import moment from 'moment';
 import { leaveGroup, joinGroup } from '../routes/PostList/actions';
 
 const styles = StyleSheet.create({
@@ -101,6 +102,10 @@ class GroupCard extends React.Component {
   render() {
     let subButton = null;
 
+    console.log(this.props.createdDate);
+    const timeSince = moment(this.props.createdDate).fromNow();
+    const name = this.props.creatorId;
+
     if (this.state.subscribed) { // Check if subscribed to group
       subButton = <RaisedButton className={css(styles.subButton)} label="unsubscribe" onClick={this.handleSubscribeClick} backgroundColor={red400} labelColor={grey100} />;
     } else {
@@ -120,11 +125,11 @@ class GroupCard extends React.Component {
               </div>
               <div className={css(styles.memberInfo)}>
                 <div className={css(styles.memberIcon)}><PeopleIcon /></div>
-                <div className={css(styles.numMembers)}>8 members</div>
+                <div className={css(styles.numMembers)}>{this.props.numMembers === 1 ? `${this.props.numMembers} member` : `${this.props.numMembers} members`}</div>
               </div>
               <div className={css(styles.groupAge)}>
                 {/* turn into momentjs call for timeSince and also use string template to get group creator */}
-                Group created 9 days ago by Byrne H.
+                {`Group created ${timeSince} by ${name}`}
               </div>
             </div>
           </div>
@@ -140,6 +145,9 @@ class GroupCard extends React.Component {
 GroupCard.propTypes = {
   groupId: React.PropTypes.string.isRequired,
   title: React.PropTypes.string.isRequired,
+  createdDate: React.PropTypes.string.isRequired,
+  creatorId: React.PropTypes.string.isRequired,
+  numMembers: React.PropTypes.number.isRequired,
   subscribed: React.PropTypes.bool.isRequired,
 };
 

--- a/common/components/GroupCard.js
+++ b/common/components/GroupCard.js
@@ -10,6 +10,7 @@ import { StyleSheet, css } from 'aphrodite';
 import PeopleIcon from 'material-ui/svg-icons/social/people';
 import { Link } from 'react-router';
 import moment from 'moment';
+import { connect } from 'react-redux';
 import { toggleGroupMembership, fetchUser } from '../routes/PostList/actions';
 
 const styles = StyleSheet.create({
@@ -92,7 +93,9 @@ class GroupCard extends React.Component {
 
   handleSubscribeClick = () => {
     this.props.dispatch(toggleGroupMembership(this.props.groupId));
-    this.setState({ subscribed: !this.state.subscribed });
+    if (!this.props.error) {
+      this.setState({ subscribed: !this.state.subscribed });
+    }
   }
 
   render() {
@@ -110,7 +113,6 @@ class GroupCard extends React.Component {
 
     let subButton = null;
 
-    console.log(this.props.createdDate);
     const timeSince = moment(this.props.createdDate).fromNow();
 
     if (this.state.subscribed) { // Check if subscribed to group
@@ -152,6 +154,7 @@ class GroupCard extends React.Component {
 GroupCard.propTypes = {
   groupId: React.PropTypes.string.isRequired,
   title: React.PropTypes.string.isRequired,
+  error: React.PropTypes.string,
   description: React.PropTypes.string.isRequired,
   createdDate: React.PropTypes.string.isRequired,
   creatorName: React.PropTypes.string.isRequired,
@@ -164,6 +167,11 @@ GroupCard.defaultProps = {
   groupId: '',
   title: 'Group Title',
   subscribed: true,
+  error: '',
 };
 
-export default GroupCard;
+const mapStateToProps = state => ({
+  error: state.articles.error,
+});
+
+export default connect(mapStateToProps)(GroupCard);

--- a/common/components/GroupCard.js
+++ b/common/components/GroupCard.js
@@ -91,10 +91,8 @@ class GroupCard extends React.Component {
   };
 
   handleSubscribeClick = () => {
-    toggleGroupMembership(this.props.groupId);
+    this.props.dispatch(toggleGroupMembership(this.props.groupId));
     this.setState({ subscribed: !this.state.subscribed });
-    console.log('Calling fetchUser!');
-    this.props.dispatch(fetchUser());
   }
 
   render() {

--- a/common/components/GroupCard.js
+++ b/common/components/GroupCard.js
@@ -3,10 +3,11 @@
 
 import React from 'react';
 import { Card, CardActions } from 'material-ui/Card';
-import { yellow200, yellow400, red700, grey900, fullBlack, deepOrange100, indigo100, amber100, teal100 } from 'material-ui/styles/colors';
+import { yellow200, yellow400, red400, grey100, grey900, fullBlack, deepOrange100, indigo100, amber100, teal100 } from 'material-ui/styles/colors';
 import RaisedButton from 'material-ui/RaisedButton';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import { StyleSheet, css } from 'aphrodite';
+import PeopleIcon from 'material-ui/svg-icons/social/people';
 import { Link } from 'react-router';
 import { leaveGroup, joinGroup } from '../routes/PostList/actions';
 
@@ -17,73 +18,63 @@ const styles = StyleSheet.create({
     paddingTop: 10,
     paddingRight: 30,
     '@media (max-width: 1000px)': {
-      flexDirection: 'column',
+      flexDirection: 'column-reverse',
     },
-  },
-  articleTitleBar: {
-    paddingLeft: 30,
-    paddingTop: 10,
-    paddingRight: 10,
   },
   subButton: {
-    margin: 'auto',
-    float: 'left',
-    lign: 'right',
+    fontSize: 22,
+    fontWeight: 600,
   },
-  leftFlex: {
-    flex: 2,
+  buttonContainer: {
+    paddingRight: 20,
   },
-  rightFlex: {
-    flex: 1,
+  groupInfo: {
     display: 'flex',
-    flexDirection: 'column',
-  },
-  imageStyle: {
-    alignSelf: 'center',
-  },
-  usersAndAnnotations: {
-    display: 'flex',
-    justifyContent: 'space-around',
-    '@media (max-width: 1000px)': {
-      display: 'none',
-    },
-  },
-  cardButtons: {
-    paddingTop: 40,
-    display: 'flex',
-    alignSelf: 'center',
     justifyContent: 'center',
-    '@media (max-width: 900px)': {
+    alignItems: 'center',
+    '@media (max-width: 1000px)': {
       flexDirection: 'column',
-      margin: 10,
-      alignItems: 'center',
+      alignItems: 'flex-start',
+      justifyContent: 'flex-start',
+      paddingBottom: 20,
     },
   },
-  bottomButton: {
-    '@media (max-width: 900px)': {
-      marginTop: 15,
-    },
+  groupTitle: {
+    fontSize: 30,
+    fontWeight: 600,
   },
-  annotationTextStyle: {
-    position: 'relative',
-    fontSize: 21,
-  },
-  articleTitleTextStyle: {
-    fontWeight: 700,
-    fontSize: 33,
-  },
-  articleTextStyle: {
-    fontSize: 24,
-    fontStyle: 'italic',
-    fontWeight: 100,
-    backgroundColor: yellow200,
-  },
-  domainTextStyle: {
-    fontSize: 17,
-    textDecoration: 'underline',
-  },
-  publishedTime: {
+  groupAge: {
     fontSize: 15,
+    fontWeight: 300,
+  },
+  groupDescription: {
+    fontSize: 23,
+    fontWeight: 400,
+    paddingLeft: 30,
+    paddingTop: 20,
+  },
+  memberInfo: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingRight: 15,
+  },
+  numMembers: {
+    fontSize: 15,
+    fontWeight: 600,
+    paddingLeft: 5,
+  },
+  memberIcon: {
+    paddingLeft: 15,
+    fontSize: 20,
+    marginTop: 7,
+  },
+  cardStyle: {
+    margin: 20,
+    paddingTop: 10,
+    paddingBottom: 20,
+    paddingRight: 20,
+    // width: '100%',
   },
 });
 
@@ -111,33 +102,35 @@ class GroupCard extends React.Component {
     let subButton = null;
 
     if (this.state.subscribed) { // Check if subscribed to group
-      subButton = <RaisedButton label="unsubscribe" onClick={this.handleSubscribeClick} backgroundColor={red700} />;
+      subButton = <RaisedButton className={css(styles.subButton)} label="unsubscribe" onClick={this.handleSubscribeClick} backgroundColor={red400} labelColor={grey100} />;
     } else {
-      subButton = <RaisedButton label="subscribe" onClick={this.handleSubscribeClick} backgroundColor={yellow400} labelColor={grey900} />;
-    }
-
-    let cardStyle;
-    if (this.props.narrowCard) {
-      cardStyle = {
-        maxWidth: '40%',
-        margin: 30,
-      };
-    } else {
-      cardStyle = {
-        margin: 30,
-      };
+      subButton = <RaisedButton className={css(styles.subButton)} label="subscribe" onClick={this.handleSubscribeClick} backgroundColor={yellow200} labelColor={grey900} />;
     }
 
     return (
       <MuiThemeProvider>
-        <Card style={cardStyle}>
-          <div className={css(styles.articleTitleBar)}>
-            <p>{this.props.title}</p>
+        <Card className={css(styles.cardStyle)}>
+          <div className={css(styles.flexContainer)}>
+            <div className={css(styles.buttonContainer)}>
+              {subButton}
+            </div>
+            <div className={css(styles.groupInfo)}>
+              <div className={css(styles.groupTitle)}>
+                {this.props.title}
+              </div>
+              <div className={css(styles.memberInfo)}>
+                <div className={css(styles.memberIcon)}><PeopleIcon /></div>
+                <div className={css(styles.numMembers)}>8 members</div>
+              </div>
+              <div className={css(styles.groupAge)}>
+                {/* turn into momentjs call for timeSince and also use string template to get group creator */}
+                Group created 9 days ago by Byrne H.
+              </div>
+            </div>
           </div>
-          <div className={css(styles.subButton)}>
-            {subButton}
+          <div className={css(styles.groupDescription)}>
+            This group is dedicated to something.
           </div>
-          <div style={{ clear: 'both' }} />
         </Card>
       </MuiThemeProvider>
     );

--- a/common/components/GroupCard.js
+++ b/common/components/GroupCard.js
@@ -95,9 +95,9 @@ class GroupCard extends React.Component {
 
   handleSubscribeClick = () => {
     if (this.state.subscribed) {
-      joinGroup(this.props.groupId);
-    } else {
       leaveGroup(this.props.groupId);
+    } else {
+      joinGroup(this.props.groupId);
     }
     this.setState({ subscribed: !this.state.subscribed });
   }
@@ -106,9 +106,9 @@ class GroupCard extends React.Component {
     let subButton = null;
 
     if (this.state.subscribed) { // Check if subscribed to group
-      subButton = <RaisedButton label="subscribe" onClick={this.handleSubscribeClick} backgroundColor={yellow400} labelColor={grey900} />;
-    } else {
       subButton = <RaisedButton label="unsubscribe" onClick={this.handleSubscribeClick} backgroundColor={red700} />;
+    } else {
+      subButton = <RaisedButton label="subscribe" onClick={this.handleSubscribeClick} backgroundColor={yellow400} labelColor={grey900} />;
     }
 
     let cardStyle;

--- a/common/components/GroupCard.js
+++ b/common/components/GroupCard.js
@@ -139,7 +139,7 @@ class GroupCard extends React.Component {
 GroupCard.propTypes = {
   groupId: React.PropTypes.string.isRequired,
   title: React.PropTypes.string.isRequired,
-  subscribed: React.PropTypes.bool.isrequired,
+  subscribed: React.PropTypes.bool.isRequired,
 };
 
 GroupCard.defaultProps = {

--- a/common/components/GroupCard.js
+++ b/common/components/GroupCard.js
@@ -8,6 +8,7 @@ import RaisedButton from 'material-ui/RaisedButton';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import { StyleSheet, css } from 'aphrodite';
 import { Link } from 'react-router';
+import { leaveGroup, joinGroup } from '../routes/PostList/actions';
 
 const styles = StyleSheet.create({
   flexContainer: {
@@ -93,6 +94,11 @@ class GroupCard extends React.Component {
   };
 
   handleSubscribeClick = () => {
+    if (this.state.subscribed) {
+      joinGroup(this.props.groupId);
+    } else {
+      leaveGroup(this.props.groupId);
+    }
     this.setState({ subscribed: !this.state.subscribed });
   }
 
@@ -131,11 +137,13 @@ class GroupCard extends React.Component {
 }
 
 GroupCard.propTypes = {
+  groupId: React.PropTypes.string.isRequired,
   title: React.PropTypes.string.isRequired,
   subscribed: React.PropTypes.bool.isrequired,
 };
 
 GroupCard.defaultProps = {
+  groupId: '',
   title: 'Group Title',
   subscribed: true,
 };

--- a/common/components/TopNav.js
+++ b/common/components/TopNav.js
@@ -89,6 +89,9 @@ const styles = StyleSheet.create({
   searchBar: {
     paddingTop: '20px',
     float: 'left',
+    '@media (max-width: 900px)': {
+      display: 'none',
+    },
   },
   searchBarWrapper: {
     '@media (max-width: 900px)': {
@@ -101,6 +104,9 @@ const styles = StyleSheet.create({
     paddingRight: '25px',
     paddingLeft: '100px',
     float: 'left',
+    '@media (max-width: 900px)': {
+      display: 'none',
+    },
   },
     // flex: 1,
   link: {

--- a/common/components/TopNav.js
+++ b/common/components/TopNav.js
@@ -89,12 +89,12 @@ const styles = StyleSheet.create({
   searchBar: {
     paddingTop: '20px',
     float: 'left',
-    '@media (max-width: 900px)': {
+    '@media (max-width: 950px)': {
       display: 'none',
     },
   },
   searchBarWrapper: {
-    '@media (max-width: 900px)': {
+    '@media (max-width: 950px)': {
       display: 'none',
     },
   },
@@ -104,7 +104,7 @@ const styles = StyleSheet.create({
     paddingRight: '25px',
     paddingLeft: '100px',
     float: 'left',
-    '@media (max-width: 900px)': {
+    '@media (max-width: 950px)': {
       display: 'none',
     },
   },
@@ -207,6 +207,7 @@ class TopNav extends React.Component {
 
   handleToggle = () => {
     this.props.dispatch({ type: 'TOGGLE_SHOW_GROUPS', toggled: !this.props.toggled });
+    this.executeSearch(this.props);
   }
 
   render() {

--- a/common/components/TopNav.js
+++ b/common/components/TopNav.js
@@ -199,17 +199,22 @@ class TopNav extends React.Component {
       */
 
     /* eslint-disable */
-
+    const isFeedView = window.location.href.includes('feed') || window.location.href === 'http://notist.io/' || window.location.href === 'http://localhost:5000/';
     let annotations = [];
     let groupId = '0';
-    if (window.location.href.includes("feed")) {
+    if (isFeedView) {
       groupId = window.location.href.substr(window.location.href.lastIndexOf('/') + 1);
     }
-    const isFeedView = window.location.href.includes('feed');
+
+    if (groupId.length === 0) {
+      groupId = '0';
+    }
+    console.log(window.location.href);
+
     const isFeedOrDiscussionView = isFeedView || window.location.href.includes('discussion');
     let allComments = [];
     if (isFeedOrDiscussionView) {
-      annotations = isFeedView  ? this.props.annotationsF : this.props.annotationsD;
+      annotations = isFeedView ? this.props.annotationsF : this.props.annotationsD;
       for (let i = 0; i < annotations.length; i += 1) {
         const order = dfsTraversal(annotations[i], () => {
 
@@ -242,7 +247,7 @@ class TopNav extends React.Component {
           <div className={css(styles.toolbarContainer)}>
             <div className={css(styles.feedDetails)}>
               <div className={css(styles.feedTopRow)}>
-                <div style={feedName}>{this.props.currentFeedName || <a style={{color: white}} href="http://notist.io/">Notist</a>}</div>
+                <div style={feedName}>{this.props.currentFeedName || <a style={{ color: white }} href="http://notist.io/">Notist</a>}</div>
                 <div style={{ paddingRight: 15 }}>{subButton}</div>
                 { shouldLoadMembers ? <PeopleIcon /> : '' }
                 <div className={css(styles.numMembers)}>{shouldLoadMembers ? (totalAuthorNumber.toString().concat(totalAuthorNumber === 1 ? ' member' : ' members')) : ''}</div>

--- a/common/components/TopNav.js
+++ b/common/components/TopNav.js
@@ -119,6 +119,19 @@ const styles = StyleSheet.create({
 });
 
 function search(list, query) { // Will return the array in sorted order
+  const keyArticles = { keys: [
+    'info.title',
+    'info.domain',
+    'annotations[0]',
+  ] };
+
+  const keyGroups = { keys: [
+    'title',
+    'description',
+  ] };
+
+  const keys = this.props.toggled ? keyGroups : keyArticles;
+
   const options = {
     shouldSort: true,
     threshold: 0.5,
@@ -126,11 +139,7 @@ function search(list, query) { // Will return the array in sorted order
     distance: 100,
     maxPatternLength: 32,
     minMatchCharLength: 1,
-    keys: [
-      'info.title',
-      'info.domain',
-      'annotations[0]',
-    ],
+    keys,
   };
 
   const fuse = new Fuse(list, options);
@@ -158,8 +167,10 @@ class TopNav extends React.Component {
   handleChange = (event, index, value) => this.setState({ value });
 
   executeSearch = (props) => {
+    const searchData = (this.props.toggled ? this.props.publicgroups : this.props.data);
+
     const textfield = document.getElementById('Search');
-    const searchResults = search(this.props.data, textfield.value);
+    const searchResults = search(searchData, textfield.value);
     const searchIsEmpty = textfield.value.length === 0;
     this.props.dispatch({ type: 'EXECUTE_SEARCH', search: searchResults, searchIsEmpty });
   }
@@ -270,6 +281,8 @@ const mapStateToProps = state => ({
   data: state.articles ? state.articles.data : [],
   annotationsD: state.Discussion ? state.Discussion.annotations : [],
   annotationsF: state.articles ? state.articles.annotations : [],
+  toggled: state.articles ? state.articles.toggled : false,
+  publicgroups: state.articles ? state.articles.publicgroups : [],
 });
 
 

--- a/common/components/TopNav.js
+++ b/common/components/TopNav.js
@@ -184,27 +184,30 @@ class TopNav extends React.Component {
     this.state = {
       value: 2,
     };
+    this.getSearchData = this.getSearchData.bind(this);
+    this.executeSearch = this.executeSearch.bind(this);
+    this.handleToggle = this.handleToggle.bind(this);
+  }
+
+  getSearchData = (isToggled) => {
+    const searchData = isToggled ? this.props.publicgroups : this.props.data;
+    const textfield = document.getElementById('Search');
+    const searchResults = search(searchData, textfield.value, isToggled);
+    return searchResults;
   }
 
   handleChange = (event, index, value) => this.setState({ value });
 
   executeSearch = (props) => {
-    const searchData = (this.props.toggled ? this.props.publicgroups : this.props.data);
-
-    console.log('Hey, your search data is:');
-    console.log(searchData);
-    console.log('Toggled is: ');
-    console.log(this.props.toggled);
-
     const textfield = document.getElementById('Search');
-    const searchResults = search(searchData, textfield.value, this.props.toggled);
+    const searchResults = this.getSearchData(this.props.toggled);
     const searchIsEmpty = textfield.value.length === 0;
     this.props.dispatch({ type: 'EXECUTE_SEARCH', search: searchResults, searchIsEmpty });
     console.log('Done with executeSearch!');
   }
 
   handleToggle = () => {
-    Promise.resolve(this.props.dispatch({ type: 'TOGGLE_SHOW_GROUPS', toggled: !this.props.toggled })).then(() => this.executeSearch(this.props));
+    this.props.dispatch({ type: 'TOGGLE_SHOW_GROUPS', toggled: !this.props.toggled, search: this.getSearchData(!this.props.toggled) });
   }
 
   render() {

--- a/common/components/TopNav.js
+++ b/common/components/TopNav.js
@@ -108,6 +108,18 @@ const styles = StyleSheet.create({
       display: 'none',
     },
   },
+  thumbOff: {
+    backgroundColor: 'blue',
+  },
+  trackOff: {
+    backgroundColor: 'green',
+  },
+  thumbSwitched: {
+    backgroundColor: 'orange',
+  },
+  trackSwitched: {
+    backgroundColor: 'pink',
+  },
     // flex: 1,
   link: {
     maxWidth: 700,
@@ -289,7 +301,14 @@ class TopNav extends React.Component {
             {isFeedView ?
               <div className={css(styles.searchBarWrapper)}>
                 <div className={css(styles.toggle)}>
-                  <Toggle id="Toggle" label={`Show Groups`} labelStyle={{marginLeft: '3px', textAlign: 'left', fontSize: '8pt', display: 'block'}} onToggle={this.handleToggle} />
+                  <Toggle id="Toggle" label={`Show Groups`}
+                    labelStyle={{marginLeft: '3px', textAlign: 'left', fontSize: '8pt', display: 'block'}}
+                    onToggle={this.handleToggle}
+                    thumbStyle={styles.thumbOff}
+                    trackStyle={styles.trackOff}
+                    thumbSwitchedStyle={styles.thumbSwitched}
+                    trackSwitchedStyle={styles.trackSwitched}
+                    />
                 </div>
                 <div className={css(styles.searchBar)}>
                   <TextField id="Search" floatingLabelText="Search" onChange={this.executeSearch} />

--- a/common/components/TopNav.js
+++ b/common/components/TopNav.js
@@ -289,7 +289,7 @@ class TopNav extends React.Component {
             {isFeedView ?
               <div className={css(styles.searchBarWrapper)}>
                 <div className={css(styles.toggle)}>
-                  <Toggle id="Toggle" label={`Show Groups`} labelStyle={{marginLeft: '100px', textAlign: 'left', fontSize: '8pt', display: 'block'}} onToggle={this.handleToggle} />
+                  <Toggle id="Toggle" label={`Show Groups`} labelStyle={{marginLeft: '3px', textAlign: 'left', fontSize: '8pt', display: 'block'}} onToggle={this.handleToggle} />
                 </div>
                 <div className={css(styles.searchBar)}>
                   <TextField id="Search" floatingLabelText="Search" onChange={this.executeSearch} />

--- a/common/components/TopNav.js
+++ b/common/components/TopNav.js
@@ -13,6 +13,7 @@ import TextField from 'material-ui/TextField';
 import { connect } from 'react-redux';
 import BugReport from 'material-ui/svg-icons/action/bug-report';
 import Fuse from 'fuse.js';
+import Toggle from 'material-ui/Toggle';
 // import SettingsDialog from './SettingsDialog';
 // import NotificationsDialog from './NotificationsDialog';
 import config from '../../server/config';
@@ -86,11 +87,22 @@ const styles = StyleSheet.create({
     },
   },
   searchBar: {
+    paddingTop: '20px',
+    float: 'left',
+  },
+  searchBarWrapper: {
     '@media (max-width: 900px)': {
       display: 'none',
     },
-    // flex: 1,
   },
+  toggle: {
+    textAlign: 'left',
+    paddingTop: '10%',
+    paddingRight: '25px',
+    paddingLeft: '100px',
+    float: 'left',
+  },
+    // flex: 1,
   link: {
     maxWidth: 700,
     color: '#999',
@@ -173,6 +185,10 @@ class TopNav extends React.Component {
     const searchResults = search(searchData, textfield.value, this.props.toggled);
     const searchIsEmpty = textfield.value.length === 0;
     this.props.dispatch({ type: 'EXECUTE_SEARCH', search: searchResults, searchIsEmpty });
+  }
+
+  handleToggle = () => {
+    this.props.dispatch({ type: 'TOGGLE_SHOW_GROUPS', toggled: !this.props.toggled });
   }
 
   render() {
@@ -265,8 +281,14 @@ class TopNav extends React.Component {
               </div>
             </div>
             {isFeedView ?
-              <div className={css(styles.searchBar)}>
-                <TextField id="Search" floatingLabelText="Search" onChange={this.executeSearch} />
+              <div className={css(styles.searchBarWrapper)}>
+                <div className={css(styles.toggle)}>
+                  <Toggle id="Toggle" label={`Show Groups`} labelStyle={{marginLeft: '100px', textAlign: 'left', fontSize: '8pt', display: 'block'}} onToggle={this.handleToggle} />
+                </div>
+                <div className={css(styles.searchBar)}>
+                  <TextField id="Search" floatingLabelText="Search" onChange={this.executeSearch} />
+                </div>
+                <div style={{clear: 'both'}} />
               </div> : ''}
             <div>
               <a className={css(styles.link, styles.topLink)}

--- a/common/components/TopNav.js
+++ b/common/components/TopNav.js
@@ -183,15 +183,7 @@ class TopNav extends React.Component {
     super(props);
     this.state = {
       value: 2,
-
     };
-    this.handleSubscribeClick = this.handleSubscribeClick.bind(this);
-  }
-
-  handleChange = (event, index, value) => this.setState({ value });
-
-  handleSubscribeClick() {
-    this.setState({ subscribed: !this.state.subscribed });
   }
 
   handleChange = (event, index, value) => this.setState({ value });
@@ -199,15 +191,20 @@ class TopNav extends React.Component {
   executeSearch = (props) => {
     const searchData = (this.props.toggled ? this.props.publicgroups : this.props.data);
 
+    console.log('Hey, your search data is:');
+    console.log(searchData);
+    console.log('Toggled is: ');
+    console.log(this.props.toggled);
+
     const textfield = document.getElementById('Search');
     const searchResults = search(searchData, textfield.value, this.props.toggled);
     const searchIsEmpty = textfield.value.length === 0;
     this.props.dispatch({ type: 'EXECUTE_SEARCH', search: searchResults, searchIsEmpty });
+    console.log('Done with executeSearch!');
   }
 
   handleToggle = () => {
-    this.props.dispatch({ type: 'TOGGLE_SHOW_GROUPS', toggled: !this.props.toggled });
-    this.executeSearch(this.props);
+    Promise.resolve(this.props.dispatch({ type: 'TOGGLE_SHOW_GROUPS', toggled: !this.props.toggled })).then(() => this.executeSearch(this.props));
   }
 
   render() {

--- a/common/components/TopNav.js
+++ b/common/components/TopNav.js
@@ -118,19 +118,18 @@ const styles = StyleSheet.create({
   },
 });
 
-function search(list, query) { // Will return the array in sorted order
-  const keyArticles = { keys: [
+function search(list, query, toggled) { // Will return the array in sorted order
+  const keyArticles = [
     'info.title',
     'info.domain',
     'annotations[0]',
-  ] };
+  ];
 
-  const keyGroups = { keys: [
-    'title',
-    'description',
-  ] };
+  const keyGroups = [
+    'name',
+  ];
 
-  const keys = this.props.toggled ? keyGroups : keyArticles;
+  const keys = toggled ? keyGroups : keyArticles;
 
   const options = {
     shouldSort: true,
@@ -139,8 +138,9 @@ function search(list, query) { // Will return the array in sorted order
     distance: 100,
     maxPatternLength: 32,
     minMatchCharLength: 1,
-    keys,
   };
+
+  options.keys = keys;
 
   const fuse = new Fuse(list, options);
   const result = fuse.search(query);
@@ -153,7 +153,7 @@ class TopNav extends React.Component {
     super(props);
     this.state = {
       value: 2,
-      subscribed: false,
+
     };
     this.handleSubscribeClick = this.handleSubscribeClick.bind(this);
   }
@@ -170,7 +170,7 @@ class TopNav extends React.Component {
     const searchData = (this.props.toggled ? this.props.publicgroups : this.props.data);
 
     const textfield = document.getElementById('Search');
-    const searchResults = search(searchData, textfield.value);
+    const searchResults = search(searchData, textfield.value, this.props.toggled);
     const searchIsEmpty = textfield.value.length === 0;
     this.props.dispatch({ type: 'EXECUTE_SEARCH', search: searchResults, searchIsEmpty });
   }

--- a/common/components/TopNav.js
+++ b/common/components/TopNav.js
@@ -189,6 +189,10 @@ class TopNav extends React.Component {
     this.handleToggle = this.handleToggle.bind(this);
   }
 
+  componentDidMount() {
+    this.props.dispatch({ type: 'EXECUTE_SEARCH', search: [], searchIsEmpty: true });
+  }
+
   getSearchData = (isToggled) => {
     const searchData = isToggled ? this.props.publicgroups : this.props.data;
     const textfield = document.getElementById('Search');

--- a/common/components/TopNav.js
+++ b/common/components/TopNav.js
@@ -294,7 +294,7 @@ class TopNav extends React.Component {
                 <div className={css(styles.searchBar)}>
                   <TextField id="Search" floatingLabelText="Search" onChange={this.executeSearch} />
                 </div>
-                <div style={{clear: 'both'}} />
+                <div style={{clear: 'both'}} ></div>
               </div> : ''}
             <div>
               <a className={css(styles.link, styles.topLink)}

--- a/common/reducers/user.js
+++ b/common/reducers/user.js
@@ -26,6 +26,14 @@ function user(state = initialState, action) {
         isFetchingUser: false,
         groups: action.groups,
         username: action.username,
+        name: action.name,
+        _id: action._id,
+        bio: action.bio,
+        usersFollowingMe: action.usersFollowingMe,
+        usersIFollow: action.usersIFollow,
+        exploreNumber: action.exploreNumber,
+        numExplorations: action.numExplorations,
+        exploreStandardDev: action.exploreStandardDev,
       });
     case types.RECEIVE_GROUP:
       return Object.assign({}, state, {

--- a/common/routes/PostList/actions.js
+++ b/common/routes/PostList/actions.js
@@ -83,8 +83,13 @@ export default function loadArticles(groupId, isPublic) {
   };
 }
 
+function handleFetchPublicGroupsResponse(dispatch, groups) {
+  return dispatch({ type: 'FETCH_PUBLIC_GROUPS', publicgroups: groups });
+}
+
 export function fetchPublicGroups() {
-  console.log('Here it is: ');
-  console.log(api.fetchPublicGroups());
-  return api.fetchPublicGroups();
+  return (dispatch, getState) => {
+    api.fetchPublicGroups().then(groups =>
+      handleFetchPublicGroupsResponse(dispatch, groups));
+  };
 }

--- a/common/routes/PostList/actions.js
+++ b/common/routes/PostList/actions.js
@@ -122,6 +122,7 @@ function handleToggleMembershipResponse(dispatch, res) {
     console.log('ERROR ERROR ERROR!'); // If you see this message then it's possible for it to throw errors
     return dispatch({ type: 'LOAD_ANNOTATIONS_ERROR', error: res.ERROR });
   } else {
+    dispatch(fetchPublicGroups());
     return dispatch(fetchUser());
   }
 }

--- a/common/routes/PostList/actions.js
+++ b/common/routes/PostList/actions.js
@@ -84,5 +84,7 @@ export default function loadArticles(groupId, isPublic) {
 }
 
 export function fetchPublicGroups() {
-  return api.fetchPublicGroups;
+  console.log('Here it is: ');
+  console.log(api.fetchPublicGroups());
+  return api.fetchPublicGroups();
 }

--- a/common/routes/PostList/actions.js
+++ b/common/routes/PostList/actions.js
@@ -118,10 +118,7 @@ export function fetchPublicGroups() {
 }
 
 export function toggleGroupMembership(groupId, userId = null) {
-  api.toggleGroupMembership(groupId, userId);
-}
-
-export function leaveGroup(groupId) {
-  console.log(`About to leave group with id: ${groupId}`);
-  api.leaveGroup(groupId);
+  return (dispatch) => {
+    api.toggleGroupMembership(groupId, userId).then(dispatch(fetchUser()));
+  };
 }

--- a/common/routes/PostList/actions.js
+++ b/common/routes/PostList/actions.js
@@ -119,6 +119,6 @@ export function fetchPublicGroups() {
 
 export function toggleGroupMembership(groupId, userId = '') {
   return (dispatch) => {
-    api.toggleGroupMembership(groupId, userId).then(dispatch(fetchUser()));
+    api.toggleGroupMembership(groupId, userId).then(() => dispatch(fetchUser()));
   };
 }

--- a/common/routes/PostList/actions.js
+++ b/common/routes/PostList/actions.js
@@ -82,3 +82,7 @@ export default function loadArticles(groupId, isPublic) {
     }
   };
 }
+
+export function fetchPublicGroups() {
+  return api.fetchPublicGroups;
+}

--- a/common/routes/PostList/actions.js
+++ b/common/routes/PostList/actions.js
@@ -21,6 +21,29 @@ function loadAnnotationsSuccess(annotations) {
   };
 }
 
+export function updateUser(groups, username, _id, bio, usersFollowingMe, usersIFollow, exploreNumber, numExplorations, exploreStandardDev) {
+  return {
+    type: types.UPDATE_USER,
+    groups,
+    name,
+    _id,
+    bio,
+    usersFollowingMe,
+    usersIFollow,
+    exploreNumber,
+    numExplorations,
+    exploreStandardDev,
+  };
+}
+
+export function fetchUser() {
+  return (dispatch, getState) => {
+    api.fetchUser().then((user) => {
+      dispatch(updateUser(user.groups, user.username, user._id, user.bio, user.usersFollowingMe, user.usersIFollow, user.exploreNumber, user.numExplorations, user.exploreStandardDev));
+    });
+  };
+}
+
 function loadAnnotations(articleURI) {
   return (dispatch, getState) => {
     dispatch(loadAnnotationsRequest);
@@ -94,9 +117,8 @@ export function fetchPublicGroups() {
   };
 }
 
-export function joinGroup(groupId) {
-  console.log(`About to join group with id: ${groupId}`);
-  api.joinGroup(groupId);
+export function toggleGroupMembership(groupId, userId = null) {
+  api.toggleGroupMembership(groupId, userId);
 }
 
 export function leaveGroup(groupId) {

--- a/common/routes/PostList/actions.js
+++ b/common/routes/PostList/actions.js
@@ -117,8 +117,19 @@ export function fetchPublicGroups() {
   };
 }
 
+function handleToggleMembershipResponse(dispatch, res) {
+  if (res.ERROR) {
+    console.log('ERROR ERROR ERROR!'); // If you see this message then it's possible for it to throw errors
+    return dispatch({ type: 'LOAD_ANNOTATIONS_ERROR', error: res.ERROR });
+  } else {
+    return dispatch(fetchUser());
+  }
+}
+
 export function toggleGroupMembership(groupId, userId = '') {
   return (dispatch) => {
-    api.toggleGroupMembership(groupId, userId).then(() => dispatch(fetchUser()));
+    api.toggleGroupMembership(groupId, userId).then((res) => {
+      handleToggleMembershipResponse(dispatch, res);
+    });
   };
 }

--- a/common/routes/PostList/actions.js
+++ b/common/routes/PostList/actions.js
@@ -117,7 +117,7 @@ export function fetchPublicGroups() {
   };
 }
 
-export function toggleGroupMembership(groupId, userId = null) {
+export function toggleGroupMembership(groupId, userId = '') {
   return (dispatch) => {
     api.toggleGroupMembership(groupId, userId).then(dispatch(fetchUser()));
   };

--- a/common/routes/PostList/actions.js
+++ b/common/routes/PostList/actions.js
@@ -93,3 +93,13 @@ export function fetchPublicGroups() {
       handleFetchPublicGroupsResponse(dispatch, groups));
   };
 }
+
+export function joinGroup(groupId) {
+  console.log(`About to join group with id: ${groupId}`);
+  api.joinGroup(groupId);
+}
+
+export function leaveGroup(groupId) {
+  console.log(`About to leave group with id: ${groupId}`);
+  api.leaveGroup(groupId);
+}

--- a/common/routes/PostList/containers/ArticleList.js
+++ b/common/routes/PostList/containers/ArticleList.js
@@ -119,7 +119,7 @@ ArticleList.defaultProps = {
 };
 
 const mapStateToProps = state => ({
-  userId: '58feaa6738babe01a6ea315b', // TODO Need to update the user information obtained from API to have userID follow you around
+  userId: '58feaa6738babe01a6ea315b',                        // TODO Need to update the user information obtained from API to have userID follow you around
   data: state.articles.data,
   annotations: state.articles.annotations,
   toggled: state.articles.toggled,

--- a/common/routes/PostList/containers/ArticleList.js
+++ b/common/routes/PostList/containers/ArticleList.js
@@ -31,6 +31,7 @@ class ArticleList extends Component {
     this.fetchArticles(this.props.location.state ?
       this.props.location.state.groupId : null);
     this.fetchPublicGroups = this.fetchPublicGroups.bind(this);
+    this.props.dispatch(fetchPublicGroups());
   }
 
   componentWillReceiveProps(nextProps) {
@@ -49,7 +50,6 @@ class ArticleList extends Component {
 
   fetchArticles(groupId) {
     this.props.dispatch(loadArticles(groupId, groupId === null));
-    this.props.dispatch(fetchPublicGroups());
   }
 
   render() {

--- a/common/routes/PostList/containers/ArticleList.js
+++ b/common/routes/PostList/containers/ArticleList.js
@@ -6,7 +6,7 @@ import Toggle from 'material-ui/Toggle';
 import { connect } from 'react-redux';
 import loadArticles, { fetchPublicGroups } from '../actions';
 import ArticleItem from '../components/ArticleItem';
-
+import GroupCard from '../../../components/GroupCard';
 /* can uncomment out articleList to have multiple cards in one row */
 const styles = StyleSheet.create({
   root: {
@@ -39,7 +39,6 @@ class ArticleList extends Component {
     if (nextProps.location.state) {
       const currGroupId = this.props.location.state ? this.props.location.state.groupId : null;
       const nextGroupdId = nextProps.location.state.groupId;
-      this.fetchPublicGroups();
       if (currGroupId !== nextGroupdId) {
         this.fetchArticles(nextGroupdId);
       }
@@ -78,19 +77,25 @@ class ArticleList extends Component {
             </div>}
           <div className={css(styles.articleList)}>
             {!this.props.isLoading && data &&
-              data.map(a =>
-                <ArticleItem
-                  style={{ width: '100%' }}
-                  key={a._id}
-                  title={a.info && a.info.title ? a.info.title : ''}
-                  imageURL={a.info && a.info.lead_image_url ? a.info.lead_image_url : ''}
-                  articleURI={a.uri}
-                  annotations={this.props.annotations.filter(annotation => annotation.article === a._id)}
-                  articleID={a._id}
-                  wordCount={a.word_count}
-                  datePublished={a.date_published}
-                  excerpt={a.excerpt}
-                />)}
+              data.map((a) => {
+                return !this.props.toggled ?
+                  <ArticleItem
+                    style={{ width: '100%' }}
+                    key={a._id}
+                    title={a.info && a.info.title ? a.info.title : ''}
+                    imageURL={a.info && a.info.lead_image_url ? a.info.lead_image_url : ''}
+                    articleURI={a.uri}
+                    annotations={this.props.annotations.filter(annotation => annotation.article === a._id)}
+                    articleID={a._id}
+                    wordCount={a.word_count}
+                    datePublished={a.date_published}
+                    excerpt={a.excerpt}
+                  /> :
+                  <GroupCard
+                    title={a.name}
+                    subscribed
+                  />;
+              })}
           </div>
         </div>
       </div>

--- a/common/routes/PostList/containers/ArticleList.js
+++ b/common/routes/PostList/containers/ArticleList.js
@@ -32,6 +32,7 @@ class ArticleList extends Component {
       this.props.location.state.groupId : null);
     this.fetchPublicGroups = this.fetchPublicGroups.bind(this);
     this.props.dispatch(fetchPublicGroups());
+    this.props.dispatch({ type: 'EXECUTE_SEARCH', search: [], searchIsEmpty: true });
   }
 
   componentWillReceiveProps(nextProps) {

--- a/common/routes/PostList/containers/ArticleList.js
+++ b/common/routes/PostList/containers/ArticleList.js
@@ -92,8 +92,9 @@ class ArticleList extends Component {
                     excerpt={a.excerpt}
                   /> :
                   <GroupCard
+                    groupId={a._id}
                     title={a.name}
-                    subscribed
+                    subscribed={a.members.includes(this.props.userId)}
                   />;
               })}
           </div>
@@ -118,6 +119,7 @@ ArticleList.defaultProps = {
 };
 
 const mapStateToProps = state => ({
+  userId: '58feaa6738babe01a6ea315b', // TODO Need to update the user information obtained from API to have userID follow you around
   data: state.articles.data,
   annotations: state.articles.annotations,
   toggled: state.articles.toggled,

--- a/common/routes/PostList/containers/ArticleList.js
+++ b/common/routes/PostList/containers/ArticleList.js
@@ -32,26 +32,31 @@ class ArticleList extends Component {
     this.fetchArticles = this.fetchArticles.bind(this);
     this.fetchArticles(this.props.location.state ?
       this.props.location.state.groupId : null);
+    this.fetchPublicGroups = this.fetchPublicGroups.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.location.state) {
       const currGroupId = this.props.location.state ? this.props.location.state.groupId : null;
       const nextGroupdId = nextProps.location.state.groupId;
+      this.fetchPublicGroups();
       if (currGroupId !== nextGroupdId) {
         this.fetchArticles(nextGroupdId);
       }
     }
   }
 
+  fetchPublicGroups() {
+    this.props.dispatch(fetchPublicGroups());
+  }
+
   fetchArticles(groupId) {
     this.props.dispatch(loadArticles(groupId, groupId === null));
+    this.props.dispatch(fetchPublicGroups());
   }
 
   handleChange = () => {
-    console.log('Here is what I\'m getting from calling an action that just calls api.fetchPublicGroups');
-    console.log(fetchPublicGroups());
-    this.props.dispatch({ type: 'TOGGLE_SHOW_GROUPS', toggled: !this.props.toggled, publicgroups: fetchPublicGroups() });
+    this.props.dispatch({ type: 'TOGGLE_SHOW_GROUPS', toggled: !this.props.toggled });
   }
 
   render() {
@@ -111,6 +116,7 @@ const mapStateToProps = state => ({
   data: state.articles.data,
   annotations: state.articles.annotations,
   toggled: state.articles.toggled,
+  publicgroups: state.articles.publicgroups,
   search: state.articles.search || [],
   searchIsEmpty: state.articles.searchIsEmpty,
   isLoading: state.articles.isLoading,

--- a/common/routes/PostList/containers/ArticleList.js
+++ b/common/routes/PostList/containers/ArticleList.js
@@ -1,6 +1,8 @@
 import React, { PropTypes, Component } from 'react';
 import { StyleSheet, css } from 'aphrodite';
 import Helmet from 'react-helmet';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import Toggle from 'material-ui/Toggle';
 import { connect } from 'react-redux';
 import loadArticles from '../actions';
 import ArticleItem from '../components/ArticleItem';
@@ -46,6 +48,10 @@ class ArticleList extends Component {
     this.props.dispatch(loadArticles(groupId, groupId === null));
   }
 
+  handleChange = () => {
+    this.props.dispatch({ type: 'TOGGLE_SHOW_GROUPS', toggled: !this.props.toggled });
+  }
+
   render() {
     const data = (this.props.searchIsEmpty ? this.props.data : this.props.search);
 
@@ -53,6 +59,9 @@ class ArticleList extends Component {
       <div className={css(styles.root)}>
         <div className={css(styles.subroot)}>
           <Helmet title="Annotations" />
+          <MuiThemeProvider>
+            <Toggle id="Toggle" onToggle={this.handleChange} />
+          </MuiThemeProvider>
           {this.props.isLoading &&
             <div>
               <h2>Loading....</h2>
@@ -96,6 +105,7 @@ ArticleList.defaultProps = {
 const mapStateToProps = state => ({
   data: state.articles.data,
   annotations: state.articles.annotations,
+  toggled: state.articles.toggled,
   search: state.articles.search || [],
   searchIsEmpty: state.articles.searchIsEmpty,
   isLoading: state.articles.isLoading,

--- a/common/routes/PostList/containers/ArticleList.js
+++ b/common/routes/PostList/containers/ArticleList.js
@@ -85,10 +85,12 @@ class ArticleList extends Component {
                   <GroupCard
                     groupId={a._id}
                     title={a.name}
+                    description={a.description}
                     createdDate={a.createDate}
-                    creatorId={a.creator}
+                    creatorName={a.creator.name}
                     numMembers={a.members.length}
                     subscribed={a.members.includes(this.props.userId)}
+                    dispatch={this.props.dispatch}
                   />;
               })}
           </div>

--- a/common/routes/PostList/containers/ArticleList.js
+++ b/common/routes/PostList/containers/ArticleList.js
@@ -49,15 +49,18 @@ class ArticleList extends Component {
   }
 
   fetchPublicGroups() {
-    this.props.dispatch(fetchPublicGroups());
+    return this.props.dispatch(fetchPublicGroups());
   }
 
   handleChange = () => {
-    this.props.dispatch({ type: 'TOGGLE_SHOW_GROUPS', toggled: !this.props.toggled, allpublicgroups: this.getPublicGroups() });
+    this.props.dispatch({ type: 'TOGGLE_SHOW_GROUPS', toggled: !this.props.toggled, publicgroups: this.getPublicGroups() });
   }
 
   render() {
-    const data = (this.props.searchIsEmpty ? this.props.data : this.props.search);
+    const dataArticles = (this.props.searchIsEmpty ? this.props.data : this.props.search);
+    const dataGroups = (this.props.searchIsEmpty ? this.props.publicgroups : this.props.search);
+
+    const data = (this.props.toggled ? dataGroups : dataArticles);
 
     return (
       <div className={css(styles.root)}>

--- a/common/routes/PostList/containers/ArticleList.js
+++ b/common/routes/PostList/containers/ArticleList.js
@@ -1,8 +1,6 @@
 import React, { PropTypes, Component } from 'react';
 import { StyleSheet, css } from 'aphrodite';
 import Helmet from 'react-helmet';
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
-import Toggle from 'material-ui/Toggle';
 import { connect } from 'react-redux';
 import loadArticles, { fetchPublicGroups } from '../actions';
 import ArticleItem from '../components/ArticleItem';
@@ -54,10 +52,6 @@ class ArticleList extends Component {
     this.props.dispatch(fetchPublicGroups());
   }
 
-  handleChange = () => {
-    this.props.dispatch({ type: 'TOGGLE_SHOW_GROUPS', toggled: !this.props.toggled });
-  }
-
   render() {
     const dataArticles = (this.props.searchIsEmpty ? this.props.data : this.props.search);
     const dataGroups = (this.props.searchIsEmpty ? this.props.publicgroups : this.props.search);
@@ -68,9 +62,6 @@ class ArticleList extends Component {
       <div className={css(styles.root)}>
         <div className={css(styles.subroot)}>
           <Helmet title="Annotations" />
-          <MuiThemeProvider>
-            <Toggle id="Toggle" onToggle={this.handleChange} />
-          </MuiThemeProvider>
           {this.props.isLoading &&
             <div>
               <h2>Loading....</h2>

--- a/common/routes/PostList/containers/ArticleList.js
+++ b/common/routes/PostList/containers/ArticleList.js
@@ -48,13 +48,10 @@ class ArticleList extends Component {
     this.props.dispatch(loadArticles(groupId, groupId === null));
   }
 
-  fetchPublicGroups() {
-    return this.props.dispatch(fetchPublicGroups());
-  }
-
   handleChange = () => {
-    console.log(this.fetchPublicGroups());
-    this.props.dispatch({ type: 'TOGGLE_SHOW_GROUPS', toggled: !this.props.toggled, publicgroups: this.fetchPublicGroups() });
+    console.log('Here is what I\'m getting from calling an action that just calls api.fetchPublicGroups');
+    console.log(fetchPublicGroups());
+    this.props.dispatch({ type: 'TOGGLE_SHOW_GROUPS', toggled: !this.props.toggled, publicgroups: fetchPublicGroups() });
   }
 
   render() {

--- a/common/routes/PostList/containers/ArticleList.js
+++ b/common/routes/PostList/containers/ArticleList.js
@@ -113,7 +113,7 @@ ArticleList.defaultProps = {
 };
 
 const mapStateToProps = state => ({
-  userId: '58feaa6738babe01a6ea315b',                        // TODO Need to update the user information obtained from API to have userID follow you around
+  userId: state.user._id,                        // TODO Need to update the user information obtained from API to have userID follow you around
   data: state.articles.data,
   annotations: state.articles.annotations,
   toggled: state.articles.toggled,

--- a/common/routes/PostList/containers/ArticleList.js
+++ b/common/routes/PostList/containers/ArticleList.js
@@ -85,6 +85,9 @@ class ArticleList extends Component {
                   <GroupCard
                     groupId={a._id}
                     title={a.name}
+                    createdDate={a.createDate}
+                    creatorId={a.creator}
+                    numMembers={a.members.length}
                     subscribed={a.members.includes(this.props.userId)}
                   />;
               })}

--- a/common/routes/PostList/containers/ArticleList.js
+++ b/common/routes/PostList/containers/ArticleList.js
@@ -4,7 +4,7 @@ import Helmet from 'react-helmet';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import Toggle from 'material-ui/Toggle';
 import { connect } from 'react-redux';
-import loadArticles from '../actions';
+import loadArticles, { fetchPublicGroups } from '../actions';
 import ArticleItem from '../components/ArticleItem';
 
 /* can uncomment out articleList to have multiple cards in one row */
@@ -48,8 +48,12 @@ class ArticleList extends Component {
     this.props.dispatch(loadArticles(groupId, groupId === null));
   }
 
+  fetchPublicGroups() {
+    this.props.dispatch(fetchPublicGroups());
+  }
+
   handleChange = () => {
-    this.props.dispatch({ type: 'TOGGLE_SHOW_GROUPS', toggled: !this.props.toggled });
+    this.props.dispatch({ type: 'TOGGLE_SHOW_GROUPS', toggled: !this.props.toggled, allpublicgroups: this.getPublicGroups() });
   }
 
   render() {

--- a/common/routes/PostList/containers/ArticleList.js
+++ b/common/routes/PostList/containers/ArticleList.js
@@ -53,7 +53,8 @@ class ArticleList extends Component {
   }
 
   handleChange = () => {
-    this.props.dispatch({ type: 'TOGGLE_SHOW_GROUPS', toggled: !this.props.toggled, publicgroups: this.getPublicGroups() });
+    console.log(this.fetchPublicGroups());
+    this.props.dispatch({ type: 'TOGGLE_SHOW_GROUPS', toggled: !this.props.toggled, publicgroups: this.fetchPublicGroups() });
   }
 
   render() {
@@ -74,7 +75,7 @@ class ArticleList extends Component {
               <h2>Loading....</h2>
             </div>}
           <div className={css(styles.articleList)}>
-            {!this.props.isLoading &&
+            {!this.props.isLoading && data &&
               data.map(a =>
                 <ArticleItem
                   style={{ width: '100%' }}

--- a/common/routes/PostList/reducer.js
+++ b/common/routes/PostList/reducer.js
@@ -5,6 +5,7 @@ const initialState = {
   annotations: [],
   lastFetched: null,
   publicgroups: [],
+  search: [],
   toggled: false,
   searchIsEmpty: true,
   isLoading: false,
@@ -53,6 +54,7 @@ export default function articles(state = initialState, action) {
       return Object.assign({}, state, {
         ...state,
         publicgroups: action.publicgroups,
+        search: action.publicgroups.filter(pg => state.search.map(sg => sg._id).includes(pg._id)),
       });
     default:
       return state;

--- a/common/routes/PostList/reducer.js
+++ b/common/routes/PostList/reducer.js
@@ -4,6 +4,7 @@ const initialState = {
   data: [],
   annotations: [],
   lastFetched: null,
+  toggled: false,
   searchIsEmpty: true,
   isLoading: false,
   error: null,
@@ -37,10 +38,16 @@ export default function articles(state = initialState, action) {
         isLoading: false,
       });
     case 'EXECUTE_SEARCH':
-      return { ...state,
+      return Object.assign({}, state, {
+        ...state,
         search: action.search,
         searchIsEmpty: action.searchIsEmpty,
-      };
+      });
+    case 'TOGGLE_SHOW_GROUPS':
+      return Object.assign({}, state, {
+        ...state,
+        toggled: action.toggled,
+      });
     default:
       return state;
   }

--- a/common/routes/PostList/reducer.js
+++ b/common/routes/PostList/reducer.js
@@ -47,6 +47,7 @@ export default function articles(state = initialState, action) {
       return Object.assign({}, state, {
         ...state,
         toggled: action.toggled,
+        publicgroups: action.publicgroups,
       });
     default:
       return state;

--- a/common/routes/PostList/reducer.js
+++ b/common/routes/PostList/reducer.js
@@ -48,6 +48,11 @@ export default function articles(state = initialState, action) {
       return Object.assign({}, state, {
         ...state,
         toggled: action.toggled,
+      });
+    case 'FETCH_PUBLIC_GROUPS':
+      console.log('Hello, I called the reducer!!!!!!');
+      return Object.assign({}, state, {
+        ...state,
         publicgroups: action.publicgroups,
       });
     default:

--- a/common/routes/PostList/reducer.js
+++ b/common/routes/PostList/reducer.js
@@ -4,6 +4,7 @@ const initialState = {
   data: [],
   annotations: [],
   lastFetched: null,
+  publicgroups: [],
   toggled: false,
   searchIsEmpty: true,
   isLoading: false,

--- a/common/routes/PostList/reducer.js
+++ b/common/routes/PostList/reducer.js
@@ -50,7 +50,6 @@ export default function articles(state = initialState, action) {
         toggled: action.toggled,
       });
     case 'FETCH_PUBLIC_GROUPS':
-      console.log('Hello, I called the reducer!!!!!!');
       return Object.assign({}, state, {
         ...state,
         publicgroups: action.publicgroups,

--- a/common/routes/PostList/reducer.js
+++ b/common/routes/PostList/reducer.js
@@ -49,6 +49,7 @@ export default function articles(state = initialState, action) {
       return Object.assign({}, state, {
         ...state,
         toggled: action.toggled,
+        search: action.search,
       });
     case 'FETCH_PUBLIC_GROUPS':
       return Object.assign({}, state, {

--- a/server/index.js
+++ b/server/index.js
@@ -4,7 +4,7 @@
 /* eslint-disable consistent-return */
 /* eslint-disable quotes */
 
-import newrelic from 'newrelic';
+// import newrelic from 'newrelic';
 import path from 'path';
 import http from 'http';
 import express from 'express';


### PR DESCRIPTION
Here's a cool gif: 

![notist](https://cloud.githubusercontent.com/assets/11911961/26220849/56595bf2-3be2-11e7-9483-308e9ffd6b6e.gif)


Users can join / remove themselves from public groups now and have the option to search however they want with (probably) no bugs now. The only oddity which I show in the gif is that if you are on the public group page that you remove you're still able to go to it. I think that should be correct behavior, but what do you guys think? It is public, afterall, so you should still be able to see it if you wanted to.
