### PR TITLE
Explore loading indicator

### DIFF
--- a/common/routes/Explore/components/ExploreFeed.js
+++ b/common/routes/Explore/components/ExploreFeed.js
@@ -3,7 +3,7 @@ import Helmet from 'react-helmet';
 import FlatButton from 'material-ui/FlatButton';
 import { red700, red300 } from 'material-ui/styles/colors';
 import { connect } from 'react-redux';
-import ArticleItem from '../../PostList/components/ArticleItem';
+import ExploreItem from './ExploreItem';
 import loadArticles from '../actions';
 
 class ExploreFeed extends Component {
@@ -35,16 +35,15 @@ class ExploreFeed extends Component {
           </div>}
         <div>
           { !this.props.isLoading && !this.props.error && this.props.articles.map(a =>
-            <ArticleItem
+            <ExploreItem
               style={{ width: '100%' }}
               key={a._id}
               title={a.info && a.info.title ? a.info.title : ''}
               imageURL={a.info && a.info.lead_image_url ? a.info.lead_image_url : ''}
               articleURI={a.uri}
-              annotations={a.annotations}
               articleID={a._id}
-              wordCount={a.word_count}
-              datePublished={a.info && a.info.date_published}
+              wordCount={a.info.word_count}
+              datePublished={a.info.date_published}
               excerpt={a.info && a.info.excerpt}
             />,
           )}

--- a/common/routes/Explore/components/ExploreFeed.js
+++ b/common/routes/Explore/components/ExploreFeed.js
@@ -34,7 +34,7 @@ class ExploreFeed extends Component {
             />
           </div>}
         <div>
-          {this.props.articles.map(a =>
+          { !this.props.isLoading && !this.props.error && this.props.articles.map(a =>
             <ArticleItem
               style={{ width: '100%' }}
               key={a._id}
@@ -57,6 +57,7 @@ class ExploreFeed extends Component {
 const mapStateToProps = state => ({
   articles: state.explore.articles,
   isLoading: state.explore.isLoading,
+  error: state.explore.error,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/common/routes/Explore/components/ExploreFeed.js
+++ b/common/routes/Explore/components/ExploreFeed.js
@@ -17,7 +17,12 @@ class ExploreFeed extends Component {
       <div>
         <Helmet title="Explore" />
         {this.props.isLoading &&
-          <div style={{ textAlign: 'center', margin: '0 auto', width: '100%' }}>
+          <div style={{
+            textAlign: 'center',
+            margin: '40px auto',
+            width: '100%',
+          }}
+          >
             <h1>Loading...</h1>
           </div>}
         {this.props.error &&

--- a/common/routes/Explore/components/ExploreFeed.js
+++ b/common/routes/Explore/components/ExploreFeed.js
@@ -17,8 +17,8 @@ class ExploreFeed extends Component {
       <div>
         <Helmet title="Explore" />
         {this.props.isLoading &&
-          <div>
-            <h2>Loading...</h2>
+          <div style={{ textAlign: 'center', margin: '0 auto', width: '100%' }}>
+            <h1>Loading...</h1>
           </div>}
         {this.props.error &&
           <div>

--- a/common/routes/Explore/components/ExploreItem.js
+++ b/common/routes/Explore/components/ExploreItem.js
@@ -8,30 +8,33 @@ class ExploreItem extends Component {
     super(props);
     this.state = {
       annotations: [],
-      isMounted: false,
     };
     this.updateAnnotations = this.updateAnnotations.bind(this);
     this.loadAnnotations = this.loadAnnotations.bind(this);
   }
 
   componentDidMount() {
+    document.addEventListener(this.props.articleID, this.updateAnnotations);
     this.loadAnnotations();
   }
 
   componentWillUnmount() {
-    this.setState({ isMounted: false });
+    document.removeEventListener(this.props.articleID, this.updateAnnotations);
   }
 
   loadAnnotations() {
-    this.setState({ isMounted: true });
     fetchArticleAnnotations(this.props.articleURI).then((res) => {
-      this.updateAnnotations(res);
+      const annotationsEvent = new CustomEvent(this.props.articleID, {
+        detail: res,
+      });
+      document.dispatchEvent(annotationsEvent);
     });
   }
 
-  updateAnnotations(res) {
-    if (!res.ERROR && this.state.isMounted) {
-      this.setState({ annotations: res });
+  updateAnnotations(annotationsEvent) {
+    const annotations = annotationsEvent.detail;
+    if (!annotations.ERROR) {
+      this.setState({ annotations });
     }
   }
 

--- a/common/routes/Explore/components/ExploreItem.js
+++ b/common/routes/Explore/components/ExploreItem.js
@@ -1,0 +1,64 @@
+import React, { Component, PropTypes } from 'react';
+import ArticleItem from '../../PostList/components/ArticleItem';
+import { fetchArticleAnnotations } from '../../../api';
+
+class ExploreItem extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      annotations: [],
+      isMounted: false,
+    };
+    this.updateAnnotations = this.updateAnnotations.bind(this);
+    this.loadAnnotations = this.loadAnnotations.bind(this);
+  }
+
+  componentDidMount() {
+    this.loadAnnotations();
+  }
+
+  componentWillUnmount() {
+    this.setState({ isMounted: false });
+  }
+
+  loadAnnotations() {
+    this.setState({ isMounted: true });
+    fetchArticleAnnotations(this.props.articleURI).then((res) => {
+      this.updateAnnotations(res);
+    });
+  }
+
+  updateAnnotations(res) {
+    if (!res.ERROR && this.state.isMounted) {
+      this.setState({ annotations: res });
+    }
+  }
+
+  render() {
+    return (
+      <ArticleItem
+        title={this.props.title}
+        imageURL={this.props.imageURL}
+        articleURI={this.props.articleURI}
+        annotations={this.state.annotations}
+        articleID={this.props.articleID}
+        wordCount={this.props.wordCount}
+        datePublished={this.props.datePublished}
+        excerpt={this.props.excerpt}
+      />
+    );
+  }
+}
+
+ExploreItem.propTypes = {
+  title: PropTypes.string.isRequired,
+  imageURL: PropTypes.string.isRequired,
+  articleURI: PropTypes.string.isRequired,
+  articleID: PropTypes.string.isRequired,
+  wordCount: PropTypes.number.isRequired,
+  datePublished: PropTypes.string.isRequired,
+  excerpt: PropTypes.string.isRequired,
+};
+
+export default ExploreItem;

--- a/common/routes/Explore/components/ExploreSetup.js
+++ b/common/routes/Explore/components/ExploreSetup.js
@@ -41,18 +41,22 @@ class ExploreSetup extends Component {
     super(props);
     this.state = {
       isLoading: false,
+      progress: 0,
     };
     this.handleExploreComplete = this.handleExploreComplete.bind(this);
     this.handleExploreError = this.handleExploreError.bind(this);
+    this.handleExploreProgress = this.handleExploreProgress.bind(this);
     this.startExplore = this.startExplore.bind(this);
   }
 
   componentDidMount() {
+    document.addEventListener('explore_progress', this.handleExploreProgress);
     document.addEventListener('explore_done', this.handleExploreComplete);
     document.addEventListener('explore_error', this.handleExploreError);
   }
 
   componentWillUnmount() {
+    document.removeEventListener('explore_progress', this.handleExploreProgress);
     document.removeEventListener('explore_done', this.handleExploreComplete);
     document.removeEventListener('explore_error', this.handleExploreError);
   }
@@ -67,6 +71,11 @@ class ExploreSetup extends Component {
     this.setState({ isLoading: false });
     console.log('explore errored!');
     this.props.onExploreError('error');
+  }
+
+  handleExploreProgress(progressEvent) {
+    console.log(progressEvent.detail);
+    this.setState({ progress: null });
   }
 
   startExplore() {

--- a/common/routes/Explore/components/ExploreSetup.js
+++ b/common/routes/Explore/components/ExploreSetup.js
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import Helmet from 'react-helmet';
 import { StyleSheet, css } from 'aphrodite';
+import CircularProgress from 'material-ui/CircularProgress';
 import FlatButton from 'material-ui/FlatButton';
 import { red700, red300 } from 'material-ui/styles/colors';
 
@@ -20,6 +21,9 @@ const styles = StyleSheet.create({
   exploreButton: {
     marginLeft: '30px',
     color: 'white',
+  },
+  progressContainer: {
+    marginTop: '25px',
   },
   listItem: {
     listStylePosition: 'inside',
@@ -41,7 +45,7 @@ class ExploreSetup extends Component {
     super(props);
     this.state = {
       isLoading: false,
-      progress: 0,
+      progress: [0, 282],
     };
     this.handleExploreComplete = this.handleExploreComplete.bind(this);
     this.handleExploreError = this.handleExploreError.bind(this);
@@ -74,8 +78,8 @@ class ExploreSetup extends Component {
   }
 
   handleExploreProgress(progressEvent) {
-    console.log(progressEvent.detail);
-    this.setState({ progress: null });
+    const { progress } = progressEvent.detail;
+    this.setState({ progress });
   }
 
   startExplore() {
@@ -97,18 +101,26 @@ class ExploreSetup extends Component {
         { this.state.isLoading ?
           <div style={{ textAlign: 'center' }}>
             <h1>Finding articles for you...</h1>
-            <br />
-            <h2>This may take a minute</h2>
+            <div className={css(styles.progressContainer)}>
+              <CircularProgress
+                mode="determinate"
+                value={this.state.progress[0]}
+                size={150}
+                color={red700}
+                thickness={10}
+                max={this.state.progress[1]}
+              />
+            </div>
           </div> :
           <ol>
             <li className={css(styles.listItem)}>
               <span className={css(styles.helpText)}>
-                <a href="https://chrome.google.com/webstore/detail/notist/acpmllpdmdhomcokgcacekihcfihapcf"> Download Chrome Extension </a> and enable it!
-                  </span>
+                <a href="https://chrome.google.com/webstore/detail/notist/acpmllpdmdhomcokgcacekihcfihapcf"> Download the Notist chrome extension </a>
+              </span>
             </li>
             <li className={css(styles.listItem)}>
               <span className={css(styles.helpText)}>
-                <a href="https://www.facebook.com/">Login</a> to Facebook on chrome!
+                <a href="https://www.facebook.com/">Login</a> to Facebook on chrome
                 </span>
             </li>
             <li className={css(styles.listItem)}>

--- a/common/routes/Explore/index.js
+++ b/common/routes/Explore/index.js
@@ -1,9 +1,11 @@
-import React, { Component } from 'react';
+import React, { PropTypes, Component } from 'react';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import { connect } from 'react-redux';
 import ExploreSetup from './components/ExploreSetup';
 import ExploreFeed from './components/ExploreFeed';
 import ExploreError from './components/ExploreError';
+import { fetchUser } from '../../actions/groups';
 
 const muiTheme = getMuiTheme();
 
@@ -18,6 +20,12 @@ class App extends Component {
     this.onExploreComplete = this.onExploreComplete.bind(this);
     this.onExploreError = this.onExploreError.bind(this);
     this.onErrorRetry = this.onErrorRetry.bind(this);
+    this.shouldShowSetup = this.shouldShowSetup.bind(this);
+    this.shouldShowFeed = this.shouldShowFeed.bind(this);
+  }
+
+  componentDidMount() {
+    this.props.loadUserExploreInfo();
   }
 
   onExploreComplete() {
@@ -32,19 +40,25 @@ class App extends Component {
     this.setState({ exploreError: null });
   }
 
+  shouldShowSetup() {
+    return !this.state.isExploreComplete && !this.state.exploreError && this.props.exploreNumber === -1;
+  }
+
+  shouldShowFeed() {
+    return !this.state.exploreError && (this.props.exploreNumber !== -1 || this.state.isExploreComplete);
+  }
+
   render() {
     return (
       <MuiThemeProvider muiTheme={muiTheme} >
         <div>
-          { !this.state.isExploreComplete && !this.state.exploreError &&
+          { this.shouldShowSetup() &&
             <ExploreSetup
               onExploreComplete={this.onExploreComplete}
               onExploreError={this.onExploreError}
             />
           }
-          { this.state.isExploreComplete && !this.state.exploreError &&
-            <ExploreFeed />
-          }
+          { this.shouldShowFeed() && <ExploreFeed /> }
           { this.state.exploreError &&
             <ExploreError handleRetry={this.onErrorRetry} />
           }
@@ -54,4 +68,16 @@ class App extends Component {
   }
 }
 
-export default App;
+App.propTypes = {
+  exploreNumber: PropTypes.number.isRequired,
+};
+
+const mapStateToProps = state => ({
+  exploreNumber: state.user.exploreNumber || -1,
+});
+
+const mapDispatchToProps = dispatch => ({
+  loadUserExploreInfo: () => dispatch(fetchUser()),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(App);


### PR DESCRIPTION
Changes:

- Added circular loading indicator to setup page that reflects the progress of explore algo
- If you have an explore number, it won't show setup page but will instead go directly to explore feed
- Explore cards now show annotations on the article (if it has any) or the excerpt if no annotations

![notistexplore](https://cloud.githubusercontent.com/assets/6070087/26504181/83054492-4211-11e7-86dc-a0c1ac0a87a6.gif)
